### PR TITLE
Add uv support as alternative package manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,9 @@ disclosure/*
 
 __pycache__
 
+# uv
+.venv/
+uv.lock
+
 lua/panasonic_ip_in_ip.lua
 promising/*

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ First, install the required dependencies:
 pip install -r requirements.txt
 ```
 
+### Alternative: Using uv (faster)
+
+If you prefer [uv](https://github.com/astral-sh/uv) for faster dependency management:
+
+```bash
+uv sync              # Creates venv + installs dependencies
+uv run dontlookup.py capture_file.ts  # Run with uv
+```
+
 ## Usage
 
 ### Basic Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "dontlookup"
+version = "0.1.0"
+description = "IP encapsulation parser from raw DVB-S2(X) captures"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "kaitaistruct>=0.10",
+    "dpkt>=1.9.8",
+    "crccheck>=2.2",
+    "scapy>=2.5.0",
+    "cryptography>=41.0.0",
+    "tqdm>=4.65.0",
+    "matplotlib>=3.7.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
Adds support for [uv](https://github.com/astral-sh/uv) as an optional, faster alternative to pip for dependency management. The existing pip workflow remains fully supported.

## Changes
- **Added `pyproject.toml`**: Modern Python project configuration (PEP 621) with all dependencies from `requirements.txt`
- **Updated README.md**: New optional section showing uv installation/usage
- **Updated `.gitignore`**: Added `.venv/` and `uv.lock` entries

## Benefits
- **10-100x faster** dependency installation with uv
- **Automatic virtual environment** management
- **Lock file** (`uv.lock`) for reproducible builds
- **Simplified workflow**: `uv sync` + `uv run` instead of manual venv activation
- **Backward compatible**: `requirements.txt` and pip workflow unchanged

## Usage

**With pip (existing):**
```bash
pip install -r requirements.txt
python3 dontlookup.py capture.ts
```

**With uv (new):**
```bash
uv sync
uv run dontlookup.py capture.ts
```

Users can choose their preferred tool without any breaking changes.